### PR TITLE
bot protection bypass and RAG output support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slurp-ai",
-  "version": "1.0.3",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slurp-ai",
-      "version": "1.0.3",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "@extractus/article-extractor": "^8.0.17",
@@ -18,6 +18,8 @@
         "js-yaml": "^4.1.0",
         "p-queue": "^8.1.0",
         "puppeteer": "^24.4.0",
+        "puppeteer-extra": "^3.3.6",
+        "puppeteer-extra-plugin-stealth": "^2.11.2",
         "turndown": "^7.2.0",
         "turndown-plugin-gfm": "^1.0.2",
         "zod": "^3.24.2"
@@ -1294,6 +1296,15 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -1306,6 +1317,12 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1573,6 +1590,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -1768,7 +1794,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
@@ -2094,6 +2119,34 @@
         "node": ">=12"
       }
     },
+    "node_modules/clone-deep": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+      "integrity": "sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==",
+      "license": "MIT",
+      "dependencies": {
+        "for-own": "^0.1.3",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "shallow-clone": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clone-deep/node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2128,7 +2181,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/confusing-browser-globals": {
@@ -3545,6 +3597,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -3634,7 +3707,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -4087,7 +4159,6 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -4214,6 +4285,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -4276,6 +4353,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -4558,6 +4644,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -4721,6 +4816,27 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4880,6 +4996,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/merge-deep": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
+      "integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "clone-deep": "^0.2.4",
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
@@ -4954,6 +5084,28 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT"
+    },
+    "node_modules/mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==",
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mixin-object/node_modules/for-in": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+      "integrity": "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -5409,7 +5561,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5683,6 +5834,156 @@
         "node": ">=18"
       }
     },
+    "node_modules/puppeteer-extra": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra/-/puppeteer-extra-3.3.6.tgz",
+      "integrity": "sha512-rsLBE/6mMxAjlLd06LuGacrukP2bqbzKCLzV1vrhHFavqQE/taQ2UXv3H5P0Ls7nsrASa+6x3bDbXHpqMwq+7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.0",
+        "debug": "^4.1.1",
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "@types/puppeteer": "*",
+        "puppeteer": "*",
+        "puppeteer-core": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/puppeteer": {
+          "optional": true
+        },
+        "puppeteer": {
+          "optional": true
+        },
+        "puppeteer-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin/-/puppeteer-extra-plugin-3.2.3.tgz",
+      "integrity": "sha512-6RNy0e6pH8vaS3akPIKGg28xcryKscczt4wIl0ePciZENGE2yoaQJNd17UiEbdmh5/6WW6dPcfRWT9lxBwCi2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.0",
+        "debug": "^4.1.1",
+        "merge-deep": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=9.11.2"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-stealth": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-stealth/-/puppeteer-extra-plugin-stealth-2.11.2.tgz",
+      "integrity": "sha512-bUemM5XmTj9i2ZerBzsk2AN5is0wHMNE6K0hXBzBXOzP5m5G3Wl0RHhiqKeHToe/uIH8AoZiGhc1tCkLZQPKTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "puppeteer-extra-plugin-user-preferences": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-data-dir": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-data-dir/-/puppeteer-extra-plugin-user-data-dir-2.4.1.tgz",
+      "integrity": "sha512-kH1GnCcqEDoBXO7epAse4TBPJh9tEpVEK/vkedKfjOVOhZAvLkHGc9swMs5ChrJbRnf8Hdpug6TJlEuimXNQ+g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^10.0.0",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-data-dir/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-preferences": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-preferences/-/puppeteer-extra-plugin-user-preferences-2.4.1.tgz",
+      "integrity": "sha512-i1oAZxRbc1bk8MZufKCruCEC3CCafO9RKMkkodZltI4OqibLFXF3tj6HZ4LZ9C5vCXZjYcDWazgtY69mnmrQ9A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "deepmerge": "^4.2.2",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "puppeteer-extra-plugin-user-data-dir": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
@@ -5842,7 +6143,6 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -5858,7 +6158,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5870,7 +6169,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -5891,7 +6189,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6197,6 +6494,42 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shallow-clone": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "integrity": "sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shallow-clone/node_modules/kind-of": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+      "integrity": "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shallow-clone/node_modules/lazy-cache": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+      "integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "js-yaml": "^4.1.0",
     "p-queue": "^8.1.0",
     "puppeteer": "^24.4.0",
+    "puppeteer-extra": "^3.3.6",
+    "puppeteer-extra-plugin-stealth": "^2.11.2",
     "turndown": "^7.2.0",
     "turndown-plugin-gfm": "^1.0.2",
     "zod": "^3.24.2"

--- a/src/cli.js
+++ b/src/cli.js
@@ -69,7 +69,14 @@ Options:
   --retry-count <number>   Number of retries for failed requests (default: 3)
   --retry-delay <number>   Delay between retries in ms (default: 1000)
   --base-path <url>        URL prefix required for scraped links (if SLURP_ENFORCE_BASE_PATH=true). Defaults to start URL.
+  --keep-partials          Keep individual markdown files after compilation (for RAG use)
   --yes                    Skip confirmation prompts
+
+RAG Options:
+  --rag                    Output one clean markdown file per webpage (for RAG systems)
+  --chunk                  Enable semantic chunking by headings (alternative to --rag)
+  --chunk-size <number>    Maximum tokens per chunk (default: 1000, only with --chunk)
+  --chunk-overlap <number> Overlap tokens between chunks (default: 100, only with --chunk)
 
 Compile Options:
   --input <dir>            Input directory for compiler (default: ./slurp_partials or SLURP_INPUT_DIR)
@@ -141,13 +148,24 @@ async function main() {
         : undefined,
       // Add base path handling
       basePath: params['base-path'] || url, // Default to url if --base-path is not provided
+      // Keep partials for RAG use cases
+      deletePartials: params['keep-partials'] || params.rag ? false : undefined,
+      // RAG options - one file per page with clean names
+      enableRagOutput: params.rag ? true : undefined,
+      // RAG chunking options (splits by headings)
+      enableChunking: params.chunk ? true : undefined,
+      chunkSize: params['chunk-size']
+        ? parseInt(params['chunk-size'], 10)
+        : undefined,
+      chunkOverlap: params['chunk-overlap']
+        ? parseInt(params['chunk-overlap'], 10)
+        : undefined,
     };
 
     // Compilation options can also be passed if needed, or rely on env vars within the workflow
     // preserveMetadata: ...,
     // removeNavigation: ...,
     // removeDuplicates: ...,
-    // deletePartials: ...,
     // Note: output paths are handled within runSlurpWorkflow based on env/defaults
     // [LEGACY DEBUG] log removed
     try {
@@ -232,6 +250,19 @@ async function main() {
             : undefined,
           // Add base path handling
           basePath: params['base-path'] || fetchArg, // Default to fetchArg (the url) if --base-path is not provided
+          // Keep partials for RAG/Khoj use cases
+          deletePartials:
+            params['keep-partials'] || params.rag ? false : undefined,
+          // RAG options - one file per page with clean names
+          enableRagOutput: params.rag ? true : undefined,
+          // RAG chunking options (splits by headings)
+          enableChunking: params.chunk ? true : undefined,
+          chunkSize: params['chunk-size']
+            ? parseInt(params['chunk-size'], 10)
+            : undefined,
+          chunkOverlap: params['chunk-overlap']
+            ? parseInt(params['chunk-overlap'], 10)
+            : undefined,
         };
         await runSlurpWorkflow(fetchArg, {
           ...generalWorkflowOptions,
@@ -311,6 +342,19 @@ async function main() {
           version: params.version,
           // Add base path handling
           basePath: params['base-path'] || params.url, // Default to params.url if --base-path is not provided
+          // Keep partials for RAG use cases
+          deletePartials:
+            params['keep-partials'] || params.rag ? false : undefined,
+          // RAG options - one file per page with clean names
+          enableRagOutput: params.rag ? true : undefined,
+          // RAG chunking options (splits by headings)
+          enableChunking: params.chunk ? true : undefined,
+          chunkSize: params['chunk-size']
+            ? parseInt(params['chunk-size'], 10)
+            : undefined,
+          chunkOverlap: params['chunk-overlap']
+            ? parseInt(params['chunk-overlap'], 10)
+            : undefined,
         };
         // Debug log removed
         await runSlurpWorkflow(params.url, legacyOptions);

--- a/src/utils/chunker.js
+++ b/src/utils/chunker.js
@@ -1,0 +1,308 @@
+/**
+ * Semantic chunking utility for RAG systems
+ * Splits markdown content by headings while respecting token limits
+ */
+
+/**
+ * Estimate token count (rough approximation: 1 token ≈ 4 characters)
+ * @param {string} text - Text to estimate
+ * @returns {number} Estimated token count
+ */
+function estimateTokens(text) {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Parse markdown into sections based on headings
+ * @param {string} markdown - Markdown content
+ * @returns {Array<{level: number, heading: string, content: string, startLine: number}>}
+ */
+function parseMarkdownSections(markdown) {
+  const lines = markdown.split('\n');
+  const sections = [];
+  let currentSection = null;
+  let contentLines = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+
+    if (headingMatch) {
+      // Save previous section
+      if (currentSection) {
+        currentSection.content = contentLines.join('\n').trim();
+        sections.push(currentSection);
+      }
+
+      // Start new section
+      currentSection = {
+        level: headingMatch[1].length,
+        heading: headingMatch[2].trim(),
+        content: '',
+        startLine: i,
+      };
+      contentLines = [];
+    } else if (currentSection) {
+      contentLines.push(line);
+    } else {
+      // Content before first heading
+      if (!currentSection && line.trim()) {
+        currentSection = {
+          level: 0,
+          heading: '',
+          content: '',
+          startLine: 0,
+        };
+        contentLines.push(line);
+      }
+    }
+  }
+
+  // Save last section
+  if (currentSection) {
+    currentSection.content = contentLines.join('\n').trim();
+    sections.push(currentSection);
+  }
+
+  return sections;
+}
+
+/**
+ * Build heading hierarchy for context
+ * @param {Array} sections - Parsed sections
+ * @param {number} index - Current section index
+ * @returns {string} Heading hierarchy string
+ */
+function buildHeadingHierarchy(sections, index) {
+  const currentLevel = sections[index].level;
+  const hierarchy = [];
+
+  // Walk backwards to find parent headings
+  for (let i = index; i >= 0; i--) {
+    const section = sections[i];
+    if (section.level < currentLevel || i === index) {
+      if (section.heading) {
+        hierarchy.unshift({
+          level: section.level,
+          heading: section.heading,
+        });
+      }
+    }
+    // Stop at level 1 or 2 (major sections)
+    if (section.level <= 1 && i !== index) break;
+  }
+
+  return hierarchy;
+}
+
+/**
+ * Split text into overlapping chunks respecting sentence boundaries
+ * @param {string} text - Text to split
+ * @param {number} maxTokens - Maximum tokens per chunk
+ * @param {number} overlapTokens - Overlap tokens between chunks
+ * @returns {Array<string>} Array of text chunks
+ */
+function splitTextWithOverlap(text, maxTokens, overlapTokens) {
+  if (estimateTokens(text) <= maxTokens) {
+    return [text];
+  }
+
+  const chunks = [];
+  const sentences = text.split(/(?<=[.!?])\s+/);
+  let currentChunk = [];
+  let currentTokens = 0;
+
+  for (const sentence of sentences) {
+    const sentenceTokens = estimateTokens(sentence);
+
+    if (currentTokens + sentenceTokens > maxTokens && currentChunk.length > 0) {
+      // Save current chunk
+      chunks.push(currentChunk.join(' '));
+
+      // Start new chunk with overlap
+      const overlapSentences = [];
+      let overlapCount = 0;
+      for (let i = currentChunk.length - 1; i >= 0 && overlapCount < overlapTokens; i--) {
+        overlapSentences.unshift(currentChunk[i]);
+        overlapCount += estimateTokens(currentChunk[i]);
+      }
+
+      currentChunk = overlapSentences;
+      currentTokens = overlapCount;
+    }
+
+    currentChunk.push(sentence);
+    currentTokens += sentenceTokens;
+  }
+
+  // Add remaining content
+  if (currentChunk.length > 0) {
+    chunks.push(currentChunk.join(' '));
+  }
+
+  return chunks;
+}
+
+/**
+ * Chunk markdown content for RAG systems
+ * @param {string} markdown - Markdown content to chunk
+ * @param {Object} options - Chunking options
+ * @param {number} [options.maxTokens=1000] - Maximum tokens per chunk
+ * @param {number} [options.overlapTokens=100] - Overlap tokens between chunks
+ * @param {string} [options.sourceUrl=''] - Source URL for metadata
+ * @param {string} [options.title=''] - Document title
+ * @returns {Array<{id: string, content: string, metadata: Object}>} Array of chunks
+ */
+function chunkMarkdown(markdown, options = {}) {
+  const {
+    maxTokens = 1000,
+    overlapTokens = 100,
+    sourceUrl = '',
+    title = '',
+  } = options;
+
+  const sections = parseMarkdownSections(markdown);
+  const chunks = [];
+  let chunkIndex = 0;
+
+  for (let i = 0; i < sections.length; i++) {
+    const section = sections[i];
+    const hierarchy = buildHeadingHierarchy(sections, i);
+
+    // Build context header from hierarchy
+    const contextHeader = hierarchy
+      .map((h) => `${'#'.repeat(h.level || 1)} ${h.heading}`)
+      .join('\n');
+
+    // Combine heading with content
+    const fullContent = section.heading
+      ? `${'#'.repeat(section.level)} ${section.heading}\n\n${section.content}`
+      : section.content;
+
+    const contentTokens = estimateTokens(fullContent);
+
+    if (contentTokens <= maxTokens) {
+      // Section fits in one chunk
+      chunks.push({
+        id: `chunk_${chunkIndex++}`,
+        content: fullContent,
+        tokens: contentTokens,
+        metadata: {
+          sourceUrl,
+          title,
+          headingHierarchy: hierarchy.map((h) => h.heading).filter(Boolean),
+          sectionHeading: section.heading || null,
+          chunkType: 'section',
+        },
+      });
+    } else {
+      // Split large section into multiple chunks
+      const textChunks = splitTextWithOverlap(
+        section.content,
+        maxTokens - estimateTokens(contextHeader) - 50, // Reserve space for context
+        overlapTokens,
+      );
+
+      for (let j = 0; j < textChunks.length; j++) {
+        const chunkContent = section.heading
+          ? `${'#'.repeat(section.level)} ${section.heading}${j > 0 ? ' (continued)' : ''}\n\n${textChunks[j]}`
+          : textChunks[j];
+
+        chunks.push({
+          id: `chunk_${chunkIndex++}`,
+          content: chunkContent,
+          tokens: estimateTokens(chunkContent),
+          metadata: {
+            sourceUrl,
+            title,
+            headingHierarchy: hierarchy.map((h) => h.heading).filter(Boolean),
+            sectionHeading: section.heading || null,
+            chunkType: j === 0 ? 'section_start' : 'section_continuation',
+            partIndex: j,
+            totalParts: textChunks.length,
+          },
+        });
+      }
+    }
+  }
+
+  return chunks;
+}
+
+/**
+ * Chunk multiple markdown files
+ * @param {Array<{content: string, url: string, title: string}>} files - Files to chunk
+ * @param {Object} options - Chunking options
+ * @returns {Array} All chunks from all files
+ */
+function chunkMultipleFiles(files, options = {}) {
+  const allChunks = [];
+
+  for (const file of files) {
+    const fileChunks = chunkMarkdown(file.content, {
+      ...options,
+      sourceUrl: file.url,
+      title: file.title,
+    });
+
+    // Add file-level metadata
+    fileChunks.forEach((chunk, index) => {
+      chunk.metadata.fileIndex = files.indexOf(file);
+      chunk.metadata.chunkIndexInFile = index;
+    });
+
+    allChunks.push(...fileChunks);
+  }
+
+  // Add global chunk indices
+  allChunks.forEach((chunk, index) => {
+    chunk.globalIndex = index;
+  });
+
+  return allChunks;
+}
+
+/**
+ * Export chunks to JSONL format (one JSON object per line)
+ * @param {Array} chunks - Chunks to export
+ * @returns {string} JSONL string
+ */
+function chunksToJsonl(chunks) {
+  return chunks.map((chunk) => JSON.stringify(chunk)).join('\n');
+}
+
+/**
+ * Export chunks to individual markdown files content
+ * @param {Array} chunks - Chunks to export
+ * @returns {Array<{filename: string, content: string}>} Files to write
+ */
+function chunksToMarkdownFiles(chunks) {
+  return chunks.map((chunk) => {
+    const frontmatter = [
+      '---',
+      `id: ${chunk.id}`,
+      `tokens: ${chunk.tokens}`,
+      `source_url: ${chunk.metadata.sourceUrl || ''}`,
+      `title: ${chunk.metadata.title || ''}`,
+      `section: ${chunk.metadata.sectionHeading || ''}`,
+      `hierarchy: ${chunk.metadata.headingHierarchy?.join(' > ') || ''}`,
+      `chunk_type: ${chunk.metadata.chunkType}`,
+      '---',
+      '',
+    ].join('\n');
+
+    return {
+      filename: `${chunk.id}.md`,
+      content: frontmatter + chunk.content,
+    };
+  });
+}
+
+export {
+  chunkMarkdown,
+  chunkMultipleFiles,
+  chunksToJsonl,
+  chunksToMarkdownFiles,
+  estimateTokens,
+  parseMarkdownSections,
+};


### PR DESCRIPTION
Enhanced slurp-ai with bot protection bypass and RAG (Retrieval-Augmented Generation) output support, enabling scraping of Cloudflare-protected or Akamai websites and outputting clean, per-page markdown files optimised for AI knowledge bases.

---
  What Was Added

  1. Bot Protection Bypass (Stealth Mode)

  - Integrated puppeteer-extra with stealth plugin to evade Cloudflare and similar bot detection
  - Added realistic browser fingerprinting (viewport, user-agent, automation flags)
  - Sites that previously failed with ERR_HTTP2_PROTOCOL_ERROR now scrape successfully

  2. RAG Output Mode (--rag)

  - Creates one markdown file per webpage with clean, descriptive filenames
  - Files named by URL path: en-help-can-i-check-in-online.md
  - Each file includes metadata (source URL, scrape date) for citation
  - Output folder: slurps/<site>-rag/

  3. Semantic Chunking (--chunk)

  - Alternative mode that splits content by markdown headings
  - Configurable chunk size and overlap for vector database optimisation
  - Supports markdown or JSONL output formats

  4. Keep Partials (--keep-partials)

  - Preserves intermediate per-page files after compilation
  - Useful for custom post-processing workflows